### PR TITLE
Reduce memory consumption during build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,6 +19,7 @@ cmake -LAH -G Ninja ${CMAKE_ARGS} \
     -DOGS_CPU_ARCHITECTURE=OFF \
     -DBUILD_SHARED_LIBS=ON \
     -DCONDA_BUILD=ON \
+    -DOGS_EIGEN_DYNAMIC_SHAPE_MATRICES=ON \
     ..
 
 cmake --build . --target install -j${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 25ec102dd11b307b743c36053b3df5f12eaf7cb43a15f307c3c04a30b9472b67
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
By setting `OGS_EIGEN_DYNAMIC_SHAPE_MATRICES=ON`, see https://www.opengeosys.org/docs/devguide/troubleshooting/build/.